### PR TITLE
Chore: Bump upstream libinjection commit to latest b9fcaaf(2023-11-23)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const LIBINJECTION_URL: &str = "https://github.com/libinjection/libinjection";
-const LIBINJECTION_COMMIT: &str = "b9fcaaf9e50e9492807b23ffcc6af46ee1f203b9";
+const LIBINJECTION_COMMIT: &str = "73268cfd85f9ee625e1d73ec2b37672bb2fd83f6";
 const BUILD_DIR_NAME: &str = "libinjection";
 
 fn clone_libinjection(build_dir: &Path, version: &str) -> Option<()> {

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const LIBINJECTION_URL: &str = "https://github.com/libinjection/libinjection";
-const LIBINJECTION_COMMIT: &str = "271bf395732dcf6fd3689d0d456813018661e48f";
+const LIBINJECTION_COMMIT: &str = "b9fcaaf9e50e9492807b23ffcc6af46ee1f203b9";
 const BUILD_DIR_NAME: &str = "libinjection";
 
 fn clone_libinjection(build_dir: &Path, version: &str) -> Option<()> {


### PR DESCRIPTION
The upstream libinjection has fixes and updates(https://github.com/libinjection/libinjection/pull/46), bump build commit to latest b9fcaaf(2023-11-23). All tests passed.

```

running 11 tests
test bindings::bindgen_test_layout___darwin_pthread_handler_rec ... ok
test bindings::bindgen_test_layout___mbstate_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_attr_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_condattr_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_mutex_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_mutexattr_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_cond_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_once_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_rwlock_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_rwlockattr_t ... ok
test bindings::bindgen_test_layout__opaque_pthread_t ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/lib_test.rs (target/debug/deps/lib_test-292520da15d29cd2)

running 2 tests
test test_xss ... ok
test test_sqli ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests libinjection

running 1 test
test src/lib.rs - (line 9) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s

```